### PR TITLE
refactor(web): update SVG handling and clean up config

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -8,15 +8,12 @@ const nextConfig = {
       },
     ],
   },
-  experimental: {
-    turbo: {
-      rules: {
-        '*.svg': {
-          loaders: ['@svgr/webpack'],
-          as: '*.js',
-        },
-      },
-    },
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: ['@svgr/webpack'],
+    });
+    return config;
   },
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/apps/web/shared/components/header/header-public.tsx
+++ b/apps/web/shared/components/header/header-public.tsx
@@ -16,7 +16,7 @@ type HeaderProps = {
 export function HeaderPublic({ light = false }: HeaderProps) {
   return (
     <Header light={light}>
-      <Container className={`w-11/12 relative z-10`}>
+      <Container className="relative z-10">
         <div className="flex items-center justify-between gap-8 pt-6 pb-3 px-2 lg:py-5 lg:px-4 ">
           <Logo light={light} />
           <Menu menuItems={MENU_ITEMS} />


### PR DESCRIPTION
- Removed experimental turbo rules for SVGs in `next.config.mjs` and integrated `@svgr/webpack` directly into the webpack configuration for better SVG management.
- Simplified the `dev` script in `package.json` by removing the `--turbopack` flag for a more stable development experience.
- Cleaned up the `HeaderPublic` component by removing unnecessary classes for a cleaner layout.