### PR TITLE
Atualizacao menu principal

### DIFF
--- a/apps/web/shared/utils/data/menu.ts
+++ b/apps/web/shared/utils/data/menu.ts
@@ -8,7 +8,7 @@ export const MENU_ITEMS: IMenuItem[] = [
     href: '#',
     items: [
       {
-        label: 'O Grupo Coobrastur',
+        label: 'Quem Somos',
         href: '#',
         description: 'Lorem ipsum dolor sit amet, consectetur.',
       },
@@ -19,6 +19,11 @@ export const MENU_ITEMS: IMenuItem[] = [
       },
       {
         label: 'Dúvidas Frequentes',
+        href: '#',
+        description: 'Lorem ipsum dolor sit amet, consectetur.',
+      },
+      {
+        label: 'Blog',
         href: '#',
         description: 'Lorem ipsum dolor sit amet, consectetur.',
       },


### PR DESCRIPTION
- Changed label from 'O Grupo Coobrastur' to 'Quem Somos' for clarity.
- Added new menu item 'Blog' with corresponding href and description for enhanced navigation.