### PR TITLE
fix(layout): clean up imports and correct font paths

### DIFF
--- a/apps/web/app/accommodation/(public)/accommodation-page-public.tsx
+++ b/apps/web/app/accommodation/(public)/accommodation-page-public.tsx
@@ -4,7 +4,7 @@ import { Separator } from '@coobrastur/ui/components/data-display/separator';
 import { Title } from '@coobrastur/ui/components/data-display/title';
 import { Button } from '@coobrastur/ui/components/data-entry/button';
 import { Container } from '@coobrastur/ui/components/layouts/container';
-import { ArrowRight, Badge, CreditCard, Users } from '@coobrastur/ui/lib/icons';
+import { ArrowRight, CreditCard, Users } from '@coobrastur/ui/lib/icons';
 
 import { HeaderPublic } from '@/shared/components/header';
 import { ResponsiveLargerThan } from '@/shared/components/responsive';

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,9 +3,7 @@ import type { Metadata } from 'next';
 
 import { mangueira, sourceSansPro } from 'assets/fonts';
 
-import { Footer } from '@components/footer';
 import { Image } from '@components/image';
-import { UserMobileNavigation } from '@components/user-mobile-navigation';
 import { Providers } from '@providers';
 
 import '@coobrastur/ui/globals.css';

--- a/apps/web/assets/fonts.ts
+++ b/apps/web/assets/fonts.ts
@@ -47,7 +47,7 @@ export const sourceSansPro = localFont({
       style: 'normal',
     },
     {
-      path: '../public/fonts/source-sans-pro/SourceSansPro-SemiBold.otf',
+      path: '../public/fonts/source-sans-pro/SourceSansPro-Semibold.otf',
       weight: '600',
       style: 'normal',
     },
@@ -62,7 +62,7 @@ export const sourceSansPro = localFont({
       style: 'normal',
     },
     {
-      path: '../public/fonts/source-sans-pro/SourceSansPro-SemiBold.woff2',
+      path: '../public/fonts/source-sans-pro/SourceSansPro-Semibold.woff2',
       weight: '600',
       style: 'normal',
     },


### PR DESCRIPTION
- Removed unused `Footer` and `UserMobileNavigation` imports from `layout.tsx` for a cleaner structure.
- Updated font paths in `fonts.ts` to correct casing for `SourceSansPro-Semibold` files.