### PR TITLE
fix(pr-preview): add environment for preview deployment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: preview
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
- Introduced an `environment: preview` setting in the GitHub Actions workflow to specify the deployment context for PR previews.