### PR TITLE
fix(pr-preview): enhance PR preview workflow with branch input options

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,6 +1,16 @@
 name: PR Preview Deployment
 
 on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: 'Nome da branch para preview (ex: feature/nova-funcionalidade)'
+        required: true
+        type: string
+      pr_number:
+        description: 'Número da PR (se existir)'
+        required: false
+        type: string
   pull_request:
     branches:
       - dev
@@ -17,6 +27,8 @@ jobs:
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_name || github.head_ref }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -27,7 +39,7 @@ jobs:
 
       - name: Create Amplify Branch
         run: |
-          BRANCH_NAME="pr-${{ github.event.pull_request.number }}"
+          BRANCH_NAME="${{ github.event.inputs.branch_name || format('pr-{0}', github.event.pull_request.number) }}"
           aws amplify create-branch \
             --app-id ${{ secrets.AMPLIFYID }} \
             --branch-name $BRANCH_NAME \
@@ -35,19 +47,21 @@ jobs:
 
       - name: Start Amplify Job
         run: |
-          BRANCH_NAME="pr-${{ github.event.pull_request.number }}"
+          BRANCH_NAME="${{ github.event.inputs.branch_name || format('pr-{0}', github.event.pull_request.number) }}"
           aws amplify start-job \
             --app-id ${{ secrets.AMPLIFYID }} \
             --branch-name $BRANCH_NAME \
             --job-type RELEASE
 
       - name: Comment PR
+        if: github.event_name == 'pull_request' || github.event.inputs.pr_number
         uses: actions/github-script@v7
         env:
           AMPLIFY_APP_ID: ${{ secrets.AMPLIFYID }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         with:
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = process.env.PR_NUMBER;
             const appId = process.env.AMPLIFY_APP_ID;
             const previewUrl = `https://pr-${prNumber}.${appId}.amplifyapp.com`;
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::417148374980:role/
-RoleforGitHubActionsAmplifyDeployments
+          role-to-assume: arn:aws:iam::417148374980:role/RoleforGitHubActionsAmplifyDeployments
           aws-region: us-east-1
 
       - name: Create Amplify Branch

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.event.inputs.branch_name || format('pr-{0}', github.event.pull_request.number) }}"
           aws amplify create-branch \
-            --app-id ${{ secrets.AMPLIFYID }} \
+            --app-id d276y3hlb1f86o \
             --branch-name $BRANCH_NAME \
             --enable-auto-build || true
 
@@ -40,7 +40,7 @@ jobs:
         run: |
           BRANCH_NAME="${{ github.event.inputs.branch_name || format('pr-{0}', github.event.pull_request.number) }}"
           aws amplify start-job \
-            --app-id ${{ secrets.AMPLIFYID }} \
+            --app-id d276y3hlb1f86o \
             --branch-name $BRANCH_NAME \
             --job-type RELEASE
 
@@ -48,7 +48,7 @@ jobs:
         if: github.event_name == 'pull_request' || github.event.inputs.pr_number
         uses: actions/github-script@v7
         env:
-          AMPLIFY_APP_ID: ${{ secrets.AMPLIFYID }}
+          AMPLIFY_APP_ID: d276y3hlb1f86o
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         with:
           script: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,16 +1,6 @@
 name: PR Preview Deployment
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch_name:
-        description: 'Nome da branch para preview (ex: feature/nova-funcionalidade)'
-        required: true
-        type: string
-      pr_number:
-        description: 'Número da PR (se existir)'
-        required: false
-        type: string
   pull_request:
     branches:
       - dev
@@ -33,8 +23,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::417148374980:role/
+RoleforGitHubActionsAmplifyDeployments
           aws-region: us-east-1
 
       - name: Create Amplify Branch

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::417148374980:role/RoleforGitHubActionsAmplifyDeployments
+          role-to-assume: arn:aws:iam::417148374980:role/CoobrasturPreviewDeploy
           role-session-name: amplify-preview-deployment
           aws-region: us-east-1
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,8 +7,9 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  id-token: write   # Required for requesting the JWT
   pull-requests: write
-  contents: read
+  contents: read    # Required for actions/checkout
 
 jobs:
   deploy:
@@ -24,6 +25,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::417148374980:role/RoleforGitHubActionsAmplifyDeployments
+          role-session-name: amplify-preview-deployment
           aws-region: us-east-1
 
       - name: Create Amplify Branch


### PR DESCRIPTION
- Added `workflow_dispatch` inputs for `branch_name` and optional `pr_number` to allow manual triggering of the preview deployment with specific branches.
- Updated the branch name handling in the Amplify steps to accommodate the new input options, improving flexibility in PR preview deployments.
- Adjusted the PR comment step to utilize the new `pr_number` input if provided.