### PR TITLE
busca de hoteis comercial

### DIFF
--- a/apps/web/app/(pages)/search-place/services.ts
+++ b/apps/web/app/(pages)/search-place/services.ts
@@ -37,7 +37,7 @@ export async function getAccommodations(value: string | null) {
         reject({
           success: false,
           data: [],
-          message: 'Nenhum hotel encontrado',
+          message: 'Nenhuma acomodação encontrada',
         });
       }
 


### PR DESCRIPTION
- Changed the error message from 'Nenhum hotel encontrado' to 'Nenhuma acomodação encontrada' for better clarity and accuracy in user feedback.